### PR TITLE
[feat] 댓글 crud 구현

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="order_mgmt@localhost" uuid="30ba6880-df26-471a-98f5-4f524c73d70d">
+    <data-source source="LOCAL" name="hunmin@localhost" uuid="4bad2f77-c836-4e46-b791-9ad581b97a6c">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://localhost:3306/order_mgmt</jdbc-url>
+      <jdbc-url>jdbc:mysql://localhost:3306/hunmin</jdbc-url>
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/hunmin.main.iml" filepath="$PROJECT_DIR$/.idea/modules/hunmin.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/hunmin.main.iml
+++ b/.idea/modules/hunmin.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/hunmin/domain/config/WebConfig.java
+++ b/src/main/java/com/hunmin/domain/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.hunmin.domain.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")  //모든 경로에 대해 CORS 허용
+                .allowedOrigins("http://localhost:3000")  //허용할 도메인
+                .allowedMethods("GET", "POST", "PUT", "DELETE",  "OPTIONS")  //허용할 HTTP 메서드
+                .allowedHeaders("*")  //허용할 헤더
+                .allowCredentials(true);  //인증 정보 허용 여부
+    }
+}

--- a/src/main/java/com/hunmin/domain/controller/CommentController.java
+++ b/src/main/java/com/hunmin/domain/controller/CommentController.java
@@ -1,0 +1,55 @@
+package com.hunmin.domain.controller;
+
+import com.hunmin.domain.dto.comment.CommentRequestDTO;
+import com.hunmin.domain.dto.comment.CommentResponseDTO;
+import com.hunmin.domain.dto.page.PageRequestDTO;
+import com.hunmin.domain.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/board/{boardId}/comment")
+public class CommentController {
+    private final CommentService commentService;
+
+    //댓글 등록
+    @PostMapping
+    public ResponseEntity<CommentResponseDTO> createComment(@PathVariable Long boardId, @RequestBody CommentRequestDTO commentRequestDTO) {
+        return ResponseEntity.ok(commentService.createComment(boardId, commentRequestDTO));
+    }
+
+    //대댓글 등록
+    @PostMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDTO> createCommentChild(@PathVariable Long boardId, @PathVariable Long commentId, @RequestBody CommentRequestDTO commentRequestDTO) {
+        return ResponseEntity.ok(commentService.createCommentChild(boardId, commentId, commentRequestDTO));
+    }
+
+    //댓글 수정
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDTO> updateComment(@PathVariable Long boardId, @PathVariable Long commentId, @RequestBody CommentRequestDTO commentRequestDTO) {
+        return ResponseEntity.ok(commentService.updateComment(commentId, commentRequestDTO));
+    }
+
+    //댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Map<String, String>> deleteComment(@PathVariable Long boardId, @PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+
+        return ResponseEntity.ok(Map.of("result", "success"));
+    }
+
+    //게시글 별 댓글 목록 조회
+    @GetMapping
+    public ResponseEntity<Page<CommentResponseDTO>> readCommentList(@PathVariable Long boardId,
+                                                                    @RequestParam(value = "page", defaultValue = "1") int page,
+                                                                    @RequestParam(value = "size", defaultValue = "5") int size) {
+        PageRequestDTO pageRequestDTO = PageRequestDTO.builder().page(page).size(size).build();
+
+        return ResponseEntity.ok(commentService.readCommentList(boardId, pageRequestDTO));
+    }
+}

--- a/src/main/java/com/hunmin/domain/controller/advice/APIControllerAdvice.java
+++ b/src/main/java/com/hunmin/domain/controller/advice/APIControllerAdvice.java
@@ -1,0 +1,20 @@
+package com.hunmin.domain.controller.advice;
+
+import com.hunmin.domain.exception.CommentTaskException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class APIControllerAdvice {
+
+    //댓글 예외 처리
+    @ExceptionHandler(CommentTaskException.class)
+    public ResponseEntity<Map<String, String>> handleCommentTaskException(CommentTaskException e) {
+        Map<String, String> map = Map.of("error", e.getMessage());
+
+        return ResponseEntity.status(e.getCode()).body(map);
+    }
+}

--- a/src/main/java/com/hunmin/domain/dto/comment/CommentRequestDTO.java
+++ b/src/main/java/com/hunmin/domain/dto/comment/CommentRequestDTO.java
@@ -1,0 +1,13 @@
+package com.hunmin.domain.dto.comment;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequestDTO {
+    private Long commentId;
+    private Long boardId;
+    private Long memberId;
+    private String content;
+}

--- a/src/main/java/com/hunmin/domain/dto/comment/CommentResponseDTO.java
+++ b/src/main/java/com/hunmin/domain/dto/comment/CommentResponseDTO.java
@@ -1,0 +1,36 @@
+package com.hunmin.domain.dto.comment;
+
+import com.hunmin.domain.entity.Comment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponseDTO {
+    private Long commentId;
+    private Long boardId;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String nickname;
+    private List<CommentResponseDTO> children;
+
+    public CommentResponseDTO(Comment comment) {
+        this.commentId = comment.getCommentId();
+        this.boardId = comment.getBoard().getBoardId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+        this.nickname = comment.getMember().getNickname();
+        this.children = (comment.getChildren() != null) ? comment.getChildren().stream()
+                .sorted(Comparator.comparing(Comment::getCommentId))
+                .map(CommentResponseDTO::new)
+                .collect(Collectors.toList()) : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/hunmin/domain/dto/page/PageRequestDTO.java
+++ b/src/main/java/com/hunmin/domain/dto/page/PageRequestDTO.java
@@ -1,0 +1,25 @@
+package com.hunmin.domain.dto.page;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Builder
+public class PageRequestDTO {
+    @Builder.Default
+    @Min(1)
+    private int page = 1;
+
+    @Builder.Default
+    @Min(5)
+    private int size = 5;
+
+    public Pageable getPageable(Sort sort) {
+        int pageNum = page < 0 ? 1 : page - 1;
+        int sizeNum = size < 5 ? 5 : size;
+
+        return PageRequest.of(pageNum, sizeNum, sort);
+    }
+}

--- a/src/main/java/com/hunmin/domain/entity/Board.java
+++ b/src/main/java/com/hunmin/domain/entity/Board.java
@@ -13,7 +13,7 @@ public class Board extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long BoardId;
+    private Long boardId;
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,7 +27,6 @@ public class Board extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String content;
-
 
     private String location;
 

--- a/src/main/java/com/hunmin/domain/entity/Comment.java
+++ b/src/main/java/com/hunmin/domain/entity/Comment.java
@@ -3,6 +3,9 @@ package com.hunmin.domain.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -21,6 +24,16 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name="member_id")
     private Member member;
 
-    private String comment;
+    private String content;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/hunmin/domain/exception/CommentException.java
+++ b/src/main/java/com/hunmin/domain/exception/CommentException.java
@@ -1,0 +1,18 @@
+package com.hunmin.domain.exception;
+
+public enum CommentException {
+    NOT_FOUND("COMMENT NOT_FOUND", 404),
+    NOT_CREATED("COMMENT NOT_CREATED", 400),
+    NOT_UPDATED("COMMENT NOT_UPDATED", 400),
+    NOT_DELETED("COMMENT NOT_DELETED", 400);
+
+    private CommentTaskException commentTaskException;
+
+    CommentException(String message, int code) {
+        commentTaskException = new CommentTaskException(message, code);
+    }
+
+    public CommentTaskException get() {
+        return commentTaskException;
+    }
+}

--- a/src/main/java/com/hunmin/domain/exception/CommentTaskException.java
+++ b/src/main/java/com/hunmin/domain/exception/CommentTaskException.java
@@ -1,0 +1,11 @@
+package com.hunmin.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentTaskException extends RuntimeException {
+    private String message;
+    private int code;
+}

--- a/src/main/java/com/hunmin/domain/repository/BoardRepository.java
+++ b/src/main/java/com/hunmin/domain/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.hunmin.domain.repository;
+
+import com.hunmin.domain.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/hunmin/domain/repository/CommentRepository.java
+++ b/src/main/java/com/hunmin/domain/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.hunmin.domain.repository;
+
+import com.hunmin.domain.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    //게시글 별 댓글 목록 조회
+    @Query("SELECT c FROM Comment c LEFT JOIN FETCH c.children WHERE c.board.boardId = :boardId AND c.parent IS NULL")
+    Page<Comment> findByBoardId(@Param("boardId") Long boardId, Pageable pageable);
+}

--- a/src/main/java/com/hunmin/domain/repository/MemberRepository.java
+++ b/src/main/java/com/hunmin/domain/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.hunmin.domain.repository;
+
+import com.hunmin.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/hunmin/domain/service/CommentService.java
+++ b/src/main/java/com/hunmin/domain/service/CommentService.java
@@ -1,0 +1,99 @@
+package com.hunmin.domain.service;
+
+import com.hunmin.domain.dto.comment.CommentRequestDTO;
+import com.hunmin.domain.dto.comment.CommentResponseDTO;
+import com.hunmin.domain.dto.page.PageRequestDTO;
+import com.hunmin.domain.entity.Board;
+import com.hunmin.domain.entity.Comment;
+import com.hunmin.domain.entity.Member;
+import com.hunmin.domain.exception.CommentException;
+import com.hunmin.domain.repository.BoardRepository;
+import com.hunmin.domain.repository.CommentRepository;
+import com.hunmin.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Log4j2
+public class CommentService {
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    //댓글 등록
+    public CommentResponseDTO createComment(Long boardId, CommentRequestDTO commentRequestDTO) {
+        try {
+            Member member = memberRepository.findById(commentRequestDTO.getMemberId()).orElseThrow();
+            Board board = boardRepository.findById(boardId).orElseThrow();
+
+            Comment comment = Comment.builder().member(member).board(board).content(commentRequestDTO.getContent()).build();
+
+            commentRepository.save(comment);
+
+            return new CommentResponseDTO(comment);
+        } catch (Exception e) {
+            log.error("Error during comment creation: ", e);
+            throw CommentException.NOT_CREATED.get();
+        }
+    }
+
+    //대댓글 등록
+    public CommentResponseDTO createCommentChild(Long boardId, Long commentId, CommentRequestDTO commentRequestDTO) {
+        try {
+            Member member = memberRepository.findById(commentRequestDTO.getMemberId()).orElseThrow();
+            Board board = boardRepository.findById(boardId).orElseThrow();
+            Comment parent = commentRepository.findById(commentId).orElseThrow();
+
+            Comment children = Comment.builder().member(member).board(board).parent(parent).content(commentRequestDTO.getContent()).build();
+
+            commentRepository.save(children);
+
+            return new CommentResponseDTO(children);
+        } catch (Exception e) {
+            throw CommentException.NOT_CREATED.get();
+        }
+    }
+
+    //댓글 수정
+    public CommentResponseDTO updateComment(Long commentId, CommentRequestDTO commentRequestDTO) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentException.NOT_FOUND::get);
+
+        try {
+            comment.changeContent(commentRequestDTO.getContent());
+
+            return new CommentResponseDTO(comment);
+        } catch (Exception e) {
+            throw CommentException.NOT_UPDATED.get();
+        }
+    }
+
+    //댓글 삭제
+    public CommentResponseDTO deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentException.NOT_FOUND::get);
+
+        try {
+            commentRepository.delete(comment);
+
+            return new CommentResponseDTO(comment);
+        } catch (Exception e) {
+            throw CommentException.NOT_DELETED.get();
+        }
+    }
+
+    //게시글 별 댓글 목록 조회
+    public Page<CommentResponseDTO> readCommentList(Long boardId, PageRequestDTO pageRequestDTO) {
+        Sort sort = Sort.by(Sort.Direction.ASC, "commentId");
+        Pageable pageable = pageRequestDTO.getPageable(sort);
+
+        Page<Comment> comments = commentRepository.findByBoardId(boardId, pageable);
+
+        return comments.map(CommentResponseDTO::new);
+    }
+}

--- a/src/test/java/com/hunmin/repository/CommentRepositoryTests.java
+++ b/src/test/java/com/hunmin/repository/CommentRepositoryTests.java
@@ -1,0 +1,105 @@
+package com.hunmin.repository;
+
+import com.hunmin.domain.entity.Board;
+import com.hunmin.domain.entity.Comment;
+import com.hunmin.domain.entity.Member;
+import com.hunmin.domain.repository.BoardRepository;
+import com.hunmin.domain.repository.CommentRepository;
+import com.hunmin.domain.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class CommentRepositoryTests {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    //댓글 등록 테스트
+    @Test
+    @Transactional
+    @Commit
+    public void testCreateComment() {
+        Member member = memberRepository.findById(1L).get();
+        Board board = boardRepository.findById(1L).get();
+
+        Comment comment = Comment.builder().board(board).member(member).content("댓글 테스트").build();
+
+        Comment savedComment = commentRepository.save(comment);
+
+        assertNotNull(savedComment);
+    }
+
+    //대댓글 등록 테스트
+    @Test
+    @Transactional
+    @Commit
+    public void testCreateCommentChildren() {
+        Member member = memberRepository.findById(1L).get();
+        Board board = boardRepository.findById(1L).get();
+        Comment parent = commentRepository.findById(1L).get();
+
+        Comment children = Comment.builder().board(board).member(member).parent(parent).content("대댓글 테스트").build();
+
+        commentRepository.save(children);
+
+        Comment savedChildren = commentRepository.save(children);
+
+        assertNotNull(savedChildren);
+    }
+
+    //댓글 수정 테스트
+    @Test
+    @Transactional
+    @Commit
+    public void testUpdateComment() {
+        Long commentId = 1L;
+        String content = "댓글 수정 테스트";
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+
+        comment.changeContent(content);
+
+        comment = commentRepository.findById(commentId).orElseThrow();
+
+        assertEquals(content, comment.getContent());
+    }
+
+    //댓글 삭제 테스트
+    @Test
+    @Transactional
+    @Commit
+    public void testDeleteComment() {
+        Long commentId = 1L;
+
+        commentRepository.deleteById(commentId);
+
+        assertTrue(commentRepository.findById(commentId).isEmpty());
+    }
+
+    //게시글 별 댓글 목록 조회 테스트
+    @Test
+    public void testReadCommentList() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Comment> comments = commentRepository.findByBoardId(1L, pageable);
+
+        assertNotNull(comments);
+
+        assertEquals(2, comments.getTotalElements());
+    }
+}


### PR DESCRIPTION
## 🔓closed #3

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 댓글의 crud와 대댓글을 구현했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
>Board의 boardId가 BoardId로 되어 있어서 수정했습니다.
>Comment 클래스이름과 테이블 안의 댓글 내용 comment가 겹쳐서 erd에서 정의한 content로 컬럼 이름을 수정했습니다.
>Board의 boardId가 BoardId로 되어 있어서 수정했습니다.
>게시판이 다 구현되면 게시판에서 바로 댓글을 불러올 수 있도록 수정할 예정입니다.
