### PR TITLE
[add] access token이 갱신될 때 refresh token도 갱신되도록 MemberController에 로직 추가

### DIFF
--- a/src/main/java/com/hunmin/domain/controller/MemberController.java
+++ b/src/main/java/com/hunmin/domain/controller/MemberController.java
@@ -106,12 +106,21 @@ public class MemberController {
         String email = jwtUtil.getEmail(refresh);
         String role = jwtUtil.getRole(refresh).replace("ROLE_", "");
 
-        // 새로운 access token 발급
-        String newAccess = jwtUtil.createJwt("access", email, MemberRole.valueOf(role), 600000L); // 10분
+        // 새로운 access & refresh token 발급
+        String newAccess = jwtUtil.createJwt("access", email, MemberRole.valueOf(role), 6000000L); // 100분
+        String newRefresh = jwtUtil.createJwt("refresh", email, MemberRole.valueOf(role), 86400000L); // 24시간
 
         // 상태 정보 반환
         response.setHeader("access", newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
 
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setHttpOnly(true);
+        return cookie;
     }
 }


### PR DESCRIPTION
## 🔓closed #94 

## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
#94 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
MemberController의 reissue 엔드 포인트 부분에서 access token을 새로 받아오는 로직에 refresh token도 같이 받아오는 로직을 
추가했고, 상태 정보 또한 갱신된 refresh token이 쿠키에 저장될 수 있도록 로직 추가하였습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/40df5a1d-b6d6-497a-814d-974153cc7743)
