### PR TITLE
[feat] 비밀번호 변경을 위한 사용자 인증, 비밀번호 변경, 보안 처리 등 현재까지 구현된 기능 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea/
+*.iml
+*.iws
+*.ipr
+.idea_modules/
+out/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
@@ -28,11 +35,38 @@
 .idea/**/dbnavigator.xml
 
 # Gradle
+target/
+build/
+*.class
+*.log
+
 .idea/**/gradle.xml
 .idea/**/libraries
 .gradle
 **/build/
 !src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
@@ -52,15 +86,6 @@ cmake-build-*/
 
 # Mongo Explorer plugin
 .idea/**/mongoSettings.xml
-
-# File-based project format
-*.iws
-
-# IntelliJ
-out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
 
 # JIRA plugin
 atlassian-ide-plugin.xml
@@ -118,11 +143,6 @@ fabric.properties
 .idea/**/azureSettings.xml
 
 ### Java ###
-# Compiled class file
-*.class
-
-# Log file
-*.log
 
 # BlueJ files
 *.ctxt
@@ -201,6 +221,9 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+*.bin
+*.lock
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,java,windows,intellij
 

--- a/hunmin-front/src/App.js
+++ b/hunmin-front/src/App.js
@@ -21,6 +21,8 @@ import WordRegisterPage from "./word/WordRegisterPage";
 import WordEditPage from "./word/WordEditPage";
 import LevelSelectPage from "./word/LevelSelectPage";
 import LearningPage from "./word/LearningPage";
+import PasswordVerify from './member/PasswordVerify';
+import PasswordUpdate from './member/PasswordUpdate';
 
 
 const App = () => {
@@ -36,7 +38,7 @@ const App = () => {
 
 const AppContent = ({ token, setToken }) => {
     const location = useLocation();
-    const hideHeaderRoutes = ['/login', '/register'];
+    const hideHeaderRoutes = ['/login', '/register', '/password/verify', '/password/update'];
 
     return (
         <>
@@ -44,6 +46,8 @@ const AppContent = ({ token, setToken }) => {
             <Routes>
                 <Route path="/login" element={<LoginForm setToken={setToken} />} />
                 <Route path="/register" element={<RegistrationForm />} />
+                <Route path="/password/verify" element={<PasswordVerify />} />
+                <Route path="/password/update" element={<PasswordUpdate />} />
                 {token ? (
                     <>
                         <Route path="/" element={<BoardListPage />} />

--- a/hunmin-front/src/member/LoginForm.js
+++ b/hunmin-front/src/member/LoginForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { TextField, Button, Container, Typography, Box } from '@mui/material';
+import { TextField, Button, Container, Typography, Box, Link } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import Cookies from 'js-cookie';
@@ -60,6 +60,11 @@ const LoginForm = ({ setToken }) => {
         }
     };
 
+    // 비밀번호 재설정 페이지로 이동
+    const handlePasswordReset = () => {
+        navigate('/password/verify');
+    };
+
     return (
         <Container component="main" maxWidth="xs">
             <Box sx={{ mt: 8 }}>
@@ -89,6 +94,16 @@ const LoginForm = ({ setToken }) => {
                     {error && <Typography color="error">{error}</Typography>}
                     <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
                         로그인
+                    </Button>
+
+                    {/* 비밀번호 재설정 버튼 */}
+                    <Button
+                        onClick={handlePasswordReset}
+                        fullWidth
+                        variant="text"
+                        sx={{ mt: 1, mb: 2 }}
+                    >
+                        비밀번호 재설정
                     </Button>
                 </form>
             </Box>

--- a/hunmin-front/src/member/PasswordUpdate.jsx
+++ b/hunmin-front/src/member/PasswordUpdate.jsx
@@ -1,0 +1,80 @@
+// PasswordUpdate.jsx 컴포넌트
+import React, { useState } from 'react';
+import { TextField, Button, Container, Typography, Box } from '@mui/material';
+import { useNavigate, useLocation } from 'react-router-dom';
+import axios from 'axios';
+
+const PasswordUpdate = () => {
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [error, setError] = useState('');
+    const navigate = useNavigate();
+    const location = useLocation();
+    const email = location.state?.email;
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (newPassword !== confirmPassword) {
+            setError('비밀번호가 일치하지 않습니다.');
+            return;
+        }
+
+        try {
+            const response = await axios.post('http://localhost:8080/api/members/password/update', {
+                email: location.state.email,
+                nickname: location.state.nickname,  // 닉네임도 필요
+                newPassword
+            });
+
+            if (response.data === "비밀번호가 성공적으로 변경되었습니다.") {
+                alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
+                navigate('/login');
+            }
+        } catch (error) {
+            console.error('Password update failed:', error.response?.data);
+            setError(error.response?.data || '비밀번호 변경 실패. 다시 시도해주세요.');
+        }
+    };
+
+    return (
+        <Container component="main" maxWidth="xs">
+            <Box sx={{ mt: 8 }}>
+                <Typography component="h1" variant="h5">
+                    새 비밀번호 설정
+                </Typography>
+                <form onSubmit={handleSubmit}>
+                    <TextField
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="새 비밀번호"
+                        type="password"
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                    />
+                    <TextField
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="새 비밀번호 확인"
+                        type="password"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                    />
+                    {error && <Typography color="error">{error}</Typography>}
+                    <Button
+                        type="submit"
+                        fullWidth
+                        variant="contained"
+                        sx={{ mt: 3, mb: 2 }}
+                    >
+                        비밀번호 변경
+                    </Button>
+                </form>
+            </Box>
+        </Container>
+    );
+};
+
+export default PasswordUpdate;

--- a/hunmin-front/src/member/PasswordVerify.jsx
+++ b/hunmin-front/src/member/PasswordVerify.jsx
@@ -1,0 +1,76 @@
+// PasswordVerify.jsx 컴포넌트
+import React, { useState } from 'react';
+import { TextField, Button, Container, Typography, Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+const PasswordVerify = () => {
+    const [email, setEmail] = useState('');
+    const [nickname, setNickname] = useState('');
+    const [error, setError] = useState('');
+    const navigate = useNavigate();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            const response = await axios.post('http://localhost:8080/api/members/password/verify', {
+                email,
+                nickname
+            });
+
+            // 응답 확인
+            console.log('Response:', response.data);
+
+            if (response.data === "사용자 확인 완료") {
+                navigate('/password/update', {
+                    state: { email,
+                             nickname
+                    }
+                });
+            }
+        } catch (error) {
+            console.error('Verification failed:', error);
+            setError('인증 실패. 이메일과 닉네임을 확인하세요.');
+        }
+    };
+
+    return (
+        <Container component="main" maxWidth="xs">
+            <Box sx={{ mt: 8 }}>
+                <Typography component="h1" variant="h5">
+                    비밀번호 재설정 인증
+                </Typography>
+                <form onSubmit={handleSubmit}>
+                    <TextField
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="이메일"
+                        autoComplete="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                    />
+                    <TextField
+                        margin="normal"
+                        required
+                        fullWidth
+                        label="닉네임"
+                        value={nickname}
+                        onChange={(e) => setNickname(e.target.value)}
+                    />
+                    {error && <Typography color="error">{error}</Typography>}
+                    <Button
+                        type="submit"
+                        fullWidth
+                        variant="contained"
+                        sx={{ mt: 3, mb: 2 }}
+                    >
+                        인증하기
+                    </Button>
+                </form>
+            </Box>
+        </Container>
+    );
+};
+
+export default PasswordVerify;

--- a/src/main/java/com/hunmin/domain/config/SecurityConfig.java
+++ b/src/main/java/com/hunmin/domain/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/login").permitAll()
                         .requestMatchers("/api/members/reissue").permitAll()
                         .requestMatchers("/api/members/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/members/password/**").permitAll()
                         .requestMatchers("/webjars/**", "/images/**", "/favicon.ico").permitAll()//웹 자원 경로 허용
                         .requestMatchers("/api/notification/**").permitAll() //알림 실시간 반영 위한 수정
                         .requestMatchers("/api/board/uploadImage/**").permitAll() //게시글 작성 이미지

--- a/src/main/java/com/hunmin/domain/controller/MemberController.java
+++ b/src/main/java/com/hunmin/domain/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.hunmin.domain.controller;
 
 import com.hunmin.domain.dto.member.MemberDTO;
+import com.hunmin.domain.dto.member.PasswordFindRequestDto;
+import com.hunmin.domain.dto.member.PasswordUpdateRequestDto;
 import com.hunmin.domain.entity.MemberRole;
 import com.hunmin.domain.entity.RefreshEntity;
 import com.hunmin.domain.jwt.JWTUtil;
@@ -149,5 +151,15 @@ public class MemberController {
         refreshEntity.setRefresh(refresh);
         refreshEntity.setExpiration(date.toString());
         refreshRepository.save(refreshEntity);
+    }
+
+    @PostMapping("/password/verify")
+    public ResponseEntity<?> verifyUser(@RequestBody PasswordFindRequestDto passwordFindRequestDto) {
+        return memberService.verifyUserForPasswordReset(passwordFindRequestDto);
+    }
+
+    @PostMapping("/password/update")
+    public ResponseEntity<?> updatePassword(@RequestBody PasswordUpdateRequestDto passwordUpdateRequestDto) {
+        return memberService.updatePassword(passwordUpdateRequestDto);
     }
 }

--- a/src/main/java/com/hunmin/domain/dto/member/PasswordFindRequestDto.java
+++ b/src/main/java/com/hunmin/domain/dto/member/PasswordFindRequestDto.java
@@ -1,0 +1,10 @@
+package com.hunmin.domain.dto.member;
+
+import lombok.Getter;
+
+@Getter
+public class PasswordFindRequestDto {
+
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/hunmin/domain/dto/member/PasswordUpdateRequestDto.java
+++ b/src/main/java/com/hunmin/domain/dto/member/PasswordUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.hunmin.domain.dto.member;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordUpdateRequestDto {
+
+    @Email
+    private String email;
+
+    @NotBlank(message = "사용자 이름은 필수 입력값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "새 비밀번호는 필수 입력값니다.")
+    private String newPassword;
+
+}

--- a/src/main/java/com/hunmin/domain/entity/Member.java
+++ b/src/main/java/com/hunmin/domain/entity/Member.java
@@ -8,7 +8,6 @@ import java.util.List;
 @Entity
 @Setter
 @Getter
-@ToString
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/hunmin/domain/jwt/JWTFilter.java
+++ b/src/main/java/com/hunmin/domain/jwt/JWTFilter.java
@@ -37,6 +37,12 @@ public class JWTFilter extends OncePerRequestFilter {
         log.info("=== JWTFilter - Request Method: {}", request.getMethod());
         log.info("=== JWTFilter - Access Token: {}", request.getHeader("Authorization"));
 
+        // 비밀번호 찾기/변경 관련 요청 필터 제외
+        if (request.getRequestURI().startsWith("/api/members/password/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // reissue 엔드포인트는 필터 적용 제외
         if ("/api/members/reissue".equals(request.getRequestURI())) {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/hunmin/domain/repository/MemberRepository.java
+++ b/src/main/java/com/hunmin/domain/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import com.hunmin.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -21,4 +22,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM ChatRoom c join c.member m on c.chatRoomId= :chatRoomId")
     Optional<Member> findByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+
+    // 비밀번호 찾기/변경 메서드
+    Optional<Member> findUserByEmailAndNickname(String email, String nickname);
+    boolean existsByEmailAndNickname(String email, String nickname);
+
+    Optional<Member> findByNicknameAndEmail(String nickname, String email);
 }


### PR DESCRIPTION
## 🔓closed #105 

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#105 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
비밀번호 변경을 위한 사용자 인증, 비밀번호 변경, 보안 처리 등 현재까지 구현하였습니다.
비밀번호를 잊어버린 경우 비밀번호 찾기 버튼을 누르면 이메일과 사용자 nickname을 바탕으로 인증 후 비밀번호를 변경합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 비밀번호 재설정 과정을 최대한 간단하게 구현하려고 로직을 짰는데 적절한지 모르겠습니다.
